### PR TITLE
Wallet API and better login handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist/bundle.js

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The data needs to be encoded into a hex string before sending
 ```javascript
 encrypt(vault, publicKey, Buffer.from("message to encrypt").toString('hex'))
   .then(encryptedMessage => {
-    console.log("encrypt: " + encryptedMessage.result.ciphertext);
+    console.log("encrypt: " + encryptedMessage.ciphertext);
   }
 );
 ```
@@ -95,9 +95,9 @@ encrypt(vault, publicKey, Buffer.from("message to encrypt").toString('hex'))
 Reverse the encryption process to get back your message
 
 ```javascript
-decrypt(vault, 'm/0', encryptedMessage.result)
+decrypt(vault, 'm/0', encryptedMessage)
   .then(message => {
-    console.log("decrypt: " + Buffer.from(message.result, 'hex').toString());
+    console.log("decrypt: " + Buffer.from(message, 'hex').toString());
   }
 );
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zippie/vault-api",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4735,6 +4735,11 @@
       "requires": {
         "setimmediate": "^1.0.4"
       }
+    },
+    "tiny-cookie": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tiny-cookie/-/tiny-cookie-2.1.2.tgz",
+      "integrity": "sha512-UMiHwxCgqJXFPmak9SCHQROpFZnSGAssUUmaOA6xrbWY5f/b5OsKDEg28+8EZd9RJMTuMkMJpuDWneF7JdxWrg=="
     },
     "to-arraybuffer": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zippie/vault-api",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -573,7 +573,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -610,7 +610,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -644,7 +644,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -1164,7 +1164,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -1177,7 +1177,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -1366,7 +1366,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -1531,7 +1531,7 @@
     },
     "events": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
     },
@@ -3056,7 +3056,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
@@ -3338,7 +3338,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -3642,7 +3642,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true
     },
@@ -3695,7 +3695,7 @@
     },
     "parse-asn1": {
       "version": "5.1.1",
-      "resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "dev": true,
       "requires": {
@@ -3873,7 +3873,7 @@
     },
     "public-encrypt": {
       "version": "4.0.2",
-      "resolved": "http://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
       "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
       "dev": true,
       "requires": {
@@ -4000,7 +4000,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -4290,7 +4290,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -4735,11 +4735,6 @@
       "requires": {
         "setimmediate": "^1.0.4"
       }
-    },
-    "tiny-cookie": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/tiny-cookie/-/tiny-cookie-2.1.2.tgz",
-      "integrity": "sha512-UMiHwxCgqJXFPmak9SCHQROpFZnSGAssUUmaOA6xrbWY5f/b5OsKDEg28+8EZd9RJMTuMkMJpuDWneF7JdxWrg=="
     },
     "to-arraybuffer": {
       "version": "1.0.1",
@@ -5270,7 +5265,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -6,15 +6,13 @@
   "author": "Zippie Ltd.",
   "license": "BSD-3-Clause",
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/zippie/vault-api.git"
+    "type": "git",
+    "url": "https://github.com/zippie/vault-api.git"
   },
   "scripts": {
     "test": "webpack; webpack-dev-server"
   },
-  "dependencies": {
-    "tiny-cookie": "^2.1.2"
-  },
+  "dependencies": {},
   "devDependencies": {
     "callbag-html": "^0.1.0",
     "webpack": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,20 @@
 {
   "name": "@zippie/vault-api",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Client API for Zippie Vault",
   "main": "src/index.js",
+  "author": "Zippie Ltd.",
+  "license": "BSD-3-Clause",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/zippie/vault-api.git"
+  },
   "scripts": {
     "test": "webpack; webpack-dev-server"
   },
-  "author": "Zippie Ltd.",
-  "license": "BSD-3-Clause",
-  "dependencies": {},
+  "dependencies": {
+    "tiny-cookie": "^2.1.2"
+  },
   "devDependencies": {
     "callbag-html": "^0.1.0",
     "webpack": "^4.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -136,11 +136,6 @@ export function init(opts) {
     window.location.hash = window.location.hash.slice(0, window.location.hash.indexOf('?'))
   }
 
-  if(isUserOnboarded() == false)
-  {
-    setCookie('autoSignInWith','zippieVault')
-  }
-
   // DApp IPC Mode, running in an IFrame inside the vault
   // XXX: maybe we should validate that we are talking to the actual vault
   if('ipc-mode' in opts)
@@ -157,7 +152,7 @@ export function init(opts) {
 
         window.addEventListener('message', onIncomingMessage)
 
-        return Promise.resolve()
+        return resolve()
       }
     )
   }
@@ -175,6 +170,11 @@ export function init(opts) {
 
   if (params['zippie-vault'] !== undefined) {
     opts.vaultURL = params['zippie-vault']
+  }
+
+  if(isUserOnboarded() == false)
+  {
+    setCookie('autoSignInWith','zippieVault')
   }
 
   // XXX: Implement per-dapp vault access token and cookie, then dapps can
@@ -210,7 +210,6 @@ export function init(opts) {
       vault = iframe.contentWindow
 
       console.log('API: Launched plainly, enclave built and waiting for ready signal.')
-      return Promise.resolve()
     })
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -177,7 +177,7 @@ export function init(opts) {
 
   // If we have no vault "magic" cookie, we have to signin, so launch vault.
   if (params['vault-cookie'] === undefined) {
-    return Promise.resolve(launch(opts.vaultURL))
+    return Promise.reject(launch(opts.vaultURL))
   }
 
   opts.vaultURL = opts.vaultURL + '#?magiccookie=' + params['vault-cookie']

--- a/src/index.js
+++ b/src/index.js
@@ -288,3 +288,5 @@ export function createButton() {
 
   return button
 }
+
+export default {parseOpts, message, init, version, config, enrollments, isCardValid, getCardEnrollUri, getWalletUri, createButton}

--- a/src/index.js
+++ b/src/index.js
@@ -93,9 +93,15 @@ function onIncomingMessage(event) {
 /**
  * Internal function, invoked when vault asks us to redirect for signin/signup.
  */
-function launch(vaultURI) {
-  console.log('API: redirecting to ' + vaultURI + '#?launch=' + window.location.href)
-  window.location = vaultURI + '#?launch=' + window.location.href
+function launch(vaultURI, returnURI) {
+  var callback = window.location.href
+
+  if(returnURI !== undefined) {
+    callback = returnURI
+  }
+
+  console.log('API: redirecting to ' + vaultURI + '#?launch=' + callback)
+  window.location = vaultURI + '#?launch=' + callback
 }
 
 /**
@@ -177,7 +183,7 @@ export function init(opts) {
 
   // If we have no vault "magic" cookie, we have to signin, so launch vault.
   if (params['vault-cookie'] === undefined) {
-    return Promise.reject(launch(opts.vaultURL))
+    return Promise.reject(launch(opts.vaultURL, opts.returnURI))
   }
 
   opts.vaultURL = opts.vaultURL + '#?magiccookie=' + params['vault-cookie']

--- a/src/index.js
+++ b/src/index.js
@@ -83,6 +83,10 @@ function onIncomingMessage(event) {
         return receiver[1](event.data)
       }
 
+      if('result' in event.data) {
+        return receiver[0](event.data.result)
+      }
+
       return receiver[0](event.data)
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -20,8 +20,6 @@
  * SOFTWARE.
 */
 
-import { getCookie, setCookie } from 'tiny-cookie'
-
 var vault = null
 
 var vaultOpts = null
@@ -172,11 +170,6 @@ export function init(opts) {
     opts.vaultURL = params['zippie-vault']
   }
 
-  if(isUserOnboarded() == false)
-  {
-    setCookie('autoSignInWith','zippieVault')
-  }
-
   // XXX: Implement per-dapp vault access token and cookie, then dapps can
   // cache in local storage their access token making this redirect only
   // required on first run.
@@ -211,21 +204,6 @@ export function init(opts) {
 
       console.log('API: Launched plainly, enclave built and waiting for ready signal.')
     })
-}
-
-export function isUserOnboarded() {
-  var isSetup = false
-
-  // Check the set cookie for returning customers
-  // TODO: integrate this with the vault better
-  var signInWith = getCookie('autoSignInWith');
-
-  if(signInWith == 'zippieVault')
-  {
-    isSetup = true
-  }
-
-  return isSetup
 }
 
 export function version() {

--- a/src/secp256k1.js
+++ b/src/secp256k1.js
@@ -5,7 +5,7 @@
  * @return {Promise} where resolve gets the public key and public extended key in a dictionary
 */
 
-exports.keyInfo = function(vault, derive) {     
+export function keyInfo(vault, derive) {     
   return new Promise(function(resolve, reject) {
     vault.message({'secp256k1KeyInfo' : { key: { derive: derive } }}).then(function(result) { 
       resolve(result.result)
@@ -21,7 +21,7 @@ exports.keyInfo = function(vault, derive) {
  * @return {Promise} a promise where the resolve returns a string with the particular signature
 */
  
-exports.sign = function(vault, derive, hash) {
+export function sign(vault, derive, hash) {
   return new Promise(function(resolve, reject) { 
     vault.message({'secp256k1Sign' : { key: { derive: derive }, hash: hash }}).then(function(result) { 
       resolve(result.result)
@@ -36,7 +36,7 @@ exports.sign = function(vault, derive, hash) {
  * @param {plaintext} plain text data to encrypt
  * @return {Promise} that resolves with the response from the vault
  */
-exports.encrypt = function (vault, pubkey, plaintext) {
+export function encrypt(vault, pubkey, plaintext) {
   return vault.message({
     secp256k1Encrypt: {
       pubkey: pubkey,
@@ -52,7 +52,7 @@ exports.encrypt = function (vault, pubkey, plaintext) {
  * @param {opts} output from secp256k1 encrypt call
  * @return {Promise} that resolves with the response from the vault
  */
-exports.decrypt = function (vault, derive, opts) {
+export function decrypt(vault, derive, opts) {
   return vault.message({
     secp256k1Decrypt: Object.assign({
       key: { derive: derive }

--- a/src/secp256k1.js
+++ b/src/secp256k1.js
@@ -6,11 +6,7 @@
 */
 
 export function keyInfo(vault, derive) {     
-  return new Promise(function(resolve, reject) {
-    vault.message({'secp256k1KeyInfo' : { key: { derive: derive } }}).then(function(result) { 
-      resolve(result.result)
-    })
-  })
+  return vault.message({'secp256k1KeyInfo' : { key: { derive: derive } }})
 }
 
 /** 
@@ -22,11 +18,7 @@ export function keyInfo(vault, derive) {
 */
  
 export function sign(vault, derive, hash) {
-  return new Promise(function(resolve, reject) { 
-    vault.message({'secp256k1Sign' : { key: { derive: derive }, hash: hash }}).then(function(result) { 
-      resolve(result.result)
-    })
-  })
+  return vault.message({'secp256k1Sign' : { key: { derive: derive }, hash: hash }})
 }
 
 /** 

--- a/src/secp256k1.js
+++ b/src/secp256k1.js
@@ -60,3 +60,4 @@ export function decrypt(vault, derive, opts) {
   })
 }
 
+export default {keyInfo, sign, encrypt, decrypt}

--- a/src/test.js
+++ b/src/test.js
@@ -53,13 +53,13 @@ vault.init(opts).then(
       // NB: Usually you would use someone elses public key
       encrypt(vault, result.pubkey, Buffer.from("message to encrypt").toString('hex'))
         .then(encResult => {
-          testLog("encrypt: " + encResult.result.ciphertext);
+          testLog("encrypt: " + encResult.ciphertext);
 
           testLog('--- Test #5: Decrypt ---')
           // Decrypt a message
-          decrypt(vault, 'm/0', encResult.result)
+          decrypt(vault, 'm/0', encResult)
             .then(message => {
-              testLog("decrypt: " + Buffer.from(message.result, 'hex').toString());
+              testLog("decrypt: " + Buffer.from(message, 'hex').toString());
             });
         });
     });
@@ -70,17 +70,25 @@ vault.init(opts).then(
     })
     
     testLog('--- Test #6 Wallet API ---')
-    wallet.walletInit(vault, 'https://my.dev.zippie.org').then(() => {
+    wallet.walletInit(vault, 'https://localhost:3000').then(() => {
       testLog('Wallet Init Return')
 
       testLog('Test Wallet Call')
       wallet.getPassportInfo(vault).then((result) => {
         testLog('Get Passport Info Return')
-        testLog(result)
+        testLog('passport info: ' +JSON.stringify(result))
+        })
+
+        wallet.getAddressForToken(vault, '0x374FaBa19192a123Fbb0c3990e3EeDcFeeaad42A').then((result) => {
+          testLog('ZIPT address: ' + JSON.stringify(result))
       })
 
-    })
+      wallet.getAddressForToken(vault, '0xd0A1E359811322d97991E03f863a0C30C2cF029C').then((result) => {
+        testLog('WETH address ' + JSON.stringify(result))
 
+        wallet.createBlankCheque(vault, result, 10, 'lets go')
+      })
+    })
   },
   error => {
     testLog("encountered error: " + error);

--- a/src/test.js
+++ b/src/test.js
@@ -2,6 +2,7 @@ import { div, h1, span, br } from 'callbag-html'
 import * as vault from './index.js'
 import { keyInfo, sign, encrypt, decrypt } from './secp256k1.js'
 import * as shajs from 'sha.js'
+import * as wallet from './wallet_api.js'
 
 function testLog(message)
 {
@@ -17,7 +18,7 @@ testLog('--- Zippie Vault Tests ---')
 
 testLog('--- Test #1: Init ---')
 
-var opts = {vaultURL: 'https://localhost:8443'}
+var opts = {vaultURL: 'https://vault.dev.zippie.org'}
 
 // Init Zippie vault
 vault.init(opts).then(
@@ -62,6 +63,24 @@ vault.init(opts).then(
             });
         });
     });
+
+    testLog('--- Test #5: Enrollments ---')
+    vault.enrollments().then( (result) => {
+      testLog("enrollments: " + JSON.stringify(result))
+    })
+    
+    testLog('--- Test #6 Wallet API ---')
+    wallet.walletInit(vault, 'https://my.dev.zippie.org').then(() => {
+      testLog('Wallet Init Return')
+
+      testLog('Test Wallet Call')
+      wallet.getPassportInfo(vault).then((result) => {
+        testLog('Get Passport Info Return')
+        testLog(result)
+      })
+
+    })
+
   },
   error => {
     testLog("encountered error: " + error);

--- a/src/wallet_api.js
+++ b/src/wallet_api.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2018 Zippie Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+*/
+
+var walletApiUrl = 'https://my.zippie.org'
+
+function messageWallet(vault, call, args)
+{
+    return new Promise(function(resolve, reject) {
+        vault.message({'IPCRouterRequest' : {target: walletApiUrl, payload: {call: call, args: args }}})
+            .then(function(result) {
+                resolve(result.result)
+            })
+    })
+}
+
+export function walletInit(vault, apiUrl) {
+
+    if(apiUrl !== undefined)
+    {
+        walletApiUrl = apiUrl
+    }
+
+    return messageWallet(vault, 'init')
+}
+
+export function getAddressForToken(vault, tokenAddr)
+{
+    return messageWallet(vault, 'getAccountForToken', tokenAddr)
+}
+
+export function getPassportInfo(vault) {
+    return messageWallet(vault, 'getPassportInfo')
+}
+
+export function getPassportImage(vault) {
+    return messageWallet(vault, 'getPassportImage')
+}

--- a/src/wallet_api.js
+++ b/src/wallet_api.js
@@ -24,12 +24,7 @@ var walletApiUrl = 'https://my.zippie.org'
 
 function messageWallet(vault, call, args)
 {
-    return new Promise(function(resolve, reject) {
-        vault.message({'IPCRouterRequest' : {target: walletApiUrl, payload: {call: call, args: args }}})
-            .then(function(result) {
-                resolve(result.result)
-            })
-    })
+    return vault.message({'IPCRouterRequest' : {target: walletApiUrl, payload: {call: call, args: args }}})
 }
 
 export function walletInit(vault, apiUrl) {
@@ -54,3 +49,9 @@ export function getPassportInfo(vault) {
 export function getPassportImage(vault) {
     return messageWallet(vault, 'getPassportImage')
 }
+
+export function createBlankCheque(vault, tokenAccount, amount, message) {
+  return messageWallet(vault, 'createBlankCheque', {tokenAccount, amount, message})
+}
+
+export default { walletInit, getAddressForToken, getPassportInfo, getPassportImage, createBlankCheque }


### PR DESCRIPTION
Stubby wallet api which wraps the IPCRouter calls.

Add the ability to set a return URL with the vault.launch, this means you can have a landing page with a login button and then a separate path on your dapp with the main application.
example page flow: 
mydapp.com/login -> vault.launch -> mydapp.com/app

When the vault needs to launch, actually reject the promise rather than resolving it, this means any logic triggered on vault.init() won't briefly get called before the window redirects.

This also unwraps a bunch of promises that were only there to unbox the `result` item and instead unboxes it in the return message handler